### PR TITLE
ci(server): update API and client URLs for deployment

### DIFF
--- a/client/src/hooks/requests.js
+++ b/client/src/hooks/requests.js
@@ -1,4 +1,4 @@
-const API_URL = 'v1';
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000/v1';
 
 // Load planets and return as JSON.
 async function httpGetPlanets() {

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -7,9 +7,11 @@ const api = require("./routes/api");
 
 const app = express();
 
+const clientOrigin = process.env.CLIENT_ORIGIN || 'http://localhost:3000';
+
 app.use(
   cors({
-    origin: "http://localhost:3000",
+    origin: "https://nasa-mission-kartikey.netlify.app", // Updated URL
   })
 );
 app.use(morgan("combined"));

--- a/server/vercel.json
+++ b/server/vercel.json
@@ -1,0 +1,17 @@
+{
+    "version": 2,
+    "builds": [
+      {
+        "src": "server/package.json",
+        "use": "@vercel/node",
+        "config": {
+        "includeFiles": ["data/**", "src/**"],
+        "maxLambdaSize": "50mb"
+      }
+      }
+    ],
+    "rewrites": [
+    { "source": "/(.*)", "destination": "/server/src/server.js" }
+  ]
+  }
+  


### PR DESCRIPTION
Update the API_URL in the client to use environment variable with a fallback to localhost. Modify the CORS origin in the server to point to the deployed client URL. Add vercel.json configuration for server deployment.